### PR TITLE
Cross-platform newline fix for BSD's & GNU's

### DIFF
--- a/reminder.plugin.zsh
+++ b/reminder.plugin.zsh
@@ -26,7 +26,9 @@ zshexit_functions+=(todo_save)
 
 function todo_add_task {
     if [[ $# -gt 0 ]] then
-      task=$(echo -E "$@" | tr '\n' '\r' | sed -e 's/\r$//' -e 's/\r/\n    /g')
+      # Cross-platform newline replacement solution for BSD's (Mac OS X) and GNU's (Linux and Cygwin)
+      # Source: http://stackoverflow.com/a/8997314/1298019
+      task=$(echo -E "$@" | tr '\n' '\000' | sed -e 's:\x00\x00.*:\n:g' -e 's/\000$//' -e 's/\000/\n    /g')
       task="  - ${fg[${todo_colors[${todo_color_index}]}]}$task$fg[default]"
       todo_tasks+="$task"
       (( todo_color_index %= ${#todo_colors} ))


### PR DESCRIPTION
Cross-platform newline replacement solution for BSD's (Mac OS X) and GNU's (Linux and Cygwin)
Source: http://stackoverflow.com/a/8997314/1298019