### PR TITLE
Adds function call to use hooks

### DIFF
--- a/reminder.plugin.zsh
+++ b/reminder.plugin.zsh
@@ -23,6 +23,7 @@ fi
 }
 
 todo_colors=(red green yellow blue magenta cyan)
+autoload -U add-zsh-hook
 add-zsh-hook precmd todo_display
 
 function todo_add_task {


### PR DESCRIPTION
Odd thing, in debian & ubuntu this is not needed but in babun (cygwin) without this call to autoload an error gets printed and the plugin does not work. Calling the autoload function before the add-zsh-hook solves the problem.